### PR TITLE
feature/vertically-linear-dropdown-options-Maro

### DIFF
--- a/src/components/tags/TextSearchAddIcon.js
+++ b/src/components/tags/TextSearchAddIcon.js
@@ -7,7 +7,6 @@ import { createTag } from '../../api';
 import i18n from '../../utilities/translations/i18n';
 import TextSearchAddIconStyles from './TextSearchAddIconStyles';
 
-
 const TextSearchAddIcon = ({ onTagAssigned, tagOptions, existingTags, onClickTextField, onBlurTextField }) => {
   const containerRef = useRef(null);
   const [isHovered, setIsHovered] = useState(false);

--- a/src/components/tags/TextSearchAddIconStyles.js
+++ b/src/components/tags/TextSearchAddIconStyles.js
@@ -43,14 +43,18 @@ const TextSearchAddIconStyles = {
       overflowX: 'hidden',
       border: '2px solid #cfb2f6',
       zIndex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      padding: '8px',
     },
     tagChip: {
-      margin: '5px',
+      margin: '5px 0',
       cursor: 'pointer',
       color: '#cfb2f6',
       borderColor: '#cfb2f6',
       backgroundColor: 'transparent',
       transition: 'background-color 0.3s, color 0.3s',
+      justifyContent: 'flex-start'
     },
     createTagWrapper: {
       display: 'flex',


### PR DESCRIPTION
updated paper and chip styles to allow short-text dropdown options to occupy a row resulting in a vertical dropdown menu.

![image](https://github.com/maropark/tagPicker/assets/40864141/563eff55-33d8-4ba1-9dd0-1d7518b1a32a)
