### PR TITLE
handle duplicates when creating tags & snackbar

### DIFF
--- a/src/Tags.js
+++ b/src/Tags.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { fetchTags, fetchUserTags, assignUserTag, removeUserTag } from "./api";
-import TagPicker from "./components/tags/TagPicker"
+import TagPicker from "./components/tags/TagPicker";
 
 export function UserTags({ user }) {
   const [allTags, setAllTags] = React.useState(null);

--- a/src/components/tags/TextSearchAddIcon.js
+++ b/src/components/tags/TextSearchAddIcon.js
@@ -3,6 +3,8 @@ import AddCircleIcon from '@mui/icons-material/AddCircle';
 import Chip from '@mui/material/Chip';
 import TextField from '@mui/material/TextField';
 import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
 import { createTag } from '../../api';
 import i18n from '../../utilities/translations/i18n';
 import TextSearchAddIconStyles from './TextSearchAddIconStyles';
@@ -13,6 +15,8 @@ const TextSearchAddIcon = ({ onTagAssigned, tagOptions, existingTags, onClickTex
   const [isClicked, setIsClicked] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [filteredTags, setFilteredTags] = useState([]);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
 
   const handleInputChange = (event) => {
     const value = event.target.value;
@@ -49,21 +53,31 @@ const TextSearchAddIcon = ({ onTagAssigned, tagOptions, existingTags, onClickTex
     if (!inputValue.trim()) return;
 
     const existingTag = tagOptions.find(tag => tag.title.toLowerCase() === inputValue.toLowerCase());
-    if (existingTag) {
+    const isAlreadyAssigned = existingTags.some(uuid => uuid === existingTag?.uuid);
+
+    if (isAlreadyAssigned) {
+      setSnackbarMessage(i18n("tagAlreadyAssigned"));
+      setSnackbarOpen(true);
+    } else if (existingTag) {
       onTagAssigned(existingTag.uuid);
     } else {
       try {
         const newTag = await createTag({ title: inputValue });
         onTagAssigned(newTag.uuid);
       } catch (error) {
-        console.error('Error creating tag:', error);
-        // TODO: implement snackbar
+        setSnackbarMessage(i18n("errorCreatingTag"));
+        setSnackbarOpen(true);
       }
     }
 
     setInputValue('');
     setIsClicked(false);
   };
+
+  const handleSnackbarClose = () => {
+    setSnackbarOpen(false);
+  };
+
 
   return (
     <div
@@ -125,6 +139,11 @@ const TextSearchAddIcon = ({ onTagAssigned, tagOptions, existingTags, onClickTex
           </div>
         </Paper>
       )}
+      <Snackbar open={snackbarOpen} autoHideDuration={6000} onClose={handleSnackbarClose}>
+        <Alert onClose={handleSnackbarClose} severity="error" sx={{ width: '100%' }}>
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </div>
   );
 };

--- a/src/components/tags/tests/TextSearchAddIcon.test.js
+++ b/src/components/tags/tests/TextSearchAddIcon.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import TextSearchAddIcon from '../TextSearchAddIcon'; // Adjust the path as needed
-import { createTag } from '../../../api'; // Adjust the path as needed
-import i18n from '../../../utilities/translations/i18n'; // Adjust the path as needed
+import TextSearchAddIcon from '../TextSearchAddIcon';
+import { createTag } from '../../../api';
+import i18n from '../../../utilities/translations/i18n';
 
 jest.mock('../../../api', () => ({
   createTag: jest.fn(),
@@ -133,6 +133,44 @@ describe('TextSearchAddIcon', () => {
     fireEvent.keyDown(screen.getByTestId('input-text-field'), { key: 'Enter', code: 'Enter' });
 
     await waitFor(() => expect(createTag).toHaveBeenCalledWith({ title: 'NewTag' }));
+  });
+
+  it('should show snackbar with appropriate message when tag is already assigned', async () => {
+    render(
+      <TextSearchAddIcon
+        onTagAssigned={onTagAssigned}
+        tagOptions={tagOptions}
+        existingTags={existingTags}
+        onClickTextField={onClickTextField}
+        onBlurTextField={onBlurTextField}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('add-icon'));
+    fireEvent.change(screen.getByTestId('input-text-field'), { target: { value: 'Tag1' } });
+    fireEvent.keyDown(screen.getByTestId('input-text-field'), { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => expect(screen.getByText(i18n("tagAlreadyAssigned"))).toBeInTheDocument());
+  });
+
+  it('should show snackbar with appropriate message when creating a tag fails', async () => {
+    createTag.mockRejectedValue(new Error('Failed to create tag'));
+
+    render(
+      <TextSearchAddIcon
+        onTagAssigned={onTagAssigned}
+        tagOptions={tagOptions}
+        existingTags={existingTags}
+        onClickTextField={onClickTextField}
+        onBlurTextField={onBlurTextField}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('add-icon'));
+    fireEvent.change(screen.getByTestId('input-text-field'), { target: { value: 'NewTag' } });
+    fireEvent.keyDown(screen.getByTestId('input-text-field'), { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => expect(screen.getByText(i18n("errorCreatingTag"))).toBeInTheDocument());
   });
 
   it('should reset input and close text field after tag is assigned', async () => {

--- a/src/utilities/translations/translations_en.js
+++ b/src/utilities/translations/translations_en.js
@@ -2,6 +2,8 @@ const translations = {
     tagsTitle: 'Tags',
     addIconDescription: 'ADD',
     createTagIconDescription: 'CREATE TAG',
+    tagAlreadyAssigned: 'The tag is already registered',
+    errorCreatingTag: 'There was an error in creating the tag',
   };
   
   export default translations;

--- a/src/utilities/translations/translations_ploc.js
+++ b/src/utilities/translations/translations_ploc.js
@@ -2,6 +2,8 @@ const translations = {
     tagsTitle: 'Tàğš',
     addIconDescription: 'ÀĐĐ',
     createTagIconDescription: 'ÇŖËÀŤË ŤÀĞ',
+    tagAlreadyAssigned: 'T̪̰h̺̻e̟̲ t͙͙a̫͓g̙͚ i̜̳s̫ a͇͍l͇r̳̪e̹a̙̻d͔͎y r̭̭e̘͕g̲͎i͉̺s̘t̻͕e̦̱r͓̠e̻̫d',
+    errorCreatingTag: 'T̪̰h̺̻e̟̲r̭̭e̹̻ w̫a̜͍s̟ a̙n̺͙ e̜̥r̳̰r̲͍o͓̠r̝ i͉̼n̳͇ c͔̺r̼̦e̯͓a̰̭ṱ͇i͍̯ṋ̬g͔̠ t̘h͇͕e͓̝ t̹a̺͕g̠',
   };
   
   export default translations;


### PR DESCRIPTION
Added duplicate handling when creating tags. 
Errors are handled & displayed by snackbar.